### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["parsing", "text-processing", "web-programming"]
 edition = "2018"
 
 [dependencies]
-backtrace = "0"
+backtrace = "0.3"
 ress = "0.11"
 resast = "0.4"
 log = "0.4"
@@ -43,7 +43,7 @@ criterion = "0.3"
 env_logger = "0.6"
 term = "0.6"
 serde_json = "1"
-serde_yaml = "0"
+serde_yaml = "0.9"
 
 [[bench]]
 name = "major_libs"


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.